### PR TITLE
Set :sandbox env when in "test" Rails env

### DIFF
--- a/app/models/spree/avatax_configuration.rb
+++ b/app/models/spree/avatax_configuration.rb
@@ -23,7 +23,9 @@ class Spree::AvataxConfiguration < Spree::Preferences::Configuration
   end
 
   def self.environment
-    if !Rails.env.test?
+    if Rails.env.test?
+      :sandbox
+    else
       :production
     end
   end

--- a/spec/models/spree/avatax_configuration_spec.rb
+++ b/spec/models/spree/avatax_configuration_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe Spree::AvataxConfiguration, type: :model do
+  subject { described_class }
+
+  describe '.environment' do
+    before { allow(Rails).to receive(:env) { rails_env.inquiry } }
+
+    context 'when in "test" Rails environment' do
+      let(:rails_env) { "test" }
+
+      it 'returns :sandbox' do
+        expect(subject.environment).to eq(:sandbox)
+      end
+    end
+
+    context 'when in "development" Rails environment' do
+      let(:rails_env) { "development" }
+
+      it 'returns :production' do
+        expect(subject.environment).to eq(:production)
+      end
+    end
+
+    context 'when in "production" Rails environment' do
+      let(:rails_env) { "production" }
+
+      it 'returns :production' do
+        expect(subject.environment).to eq(:production)
+      end
+    end
+
+    context 'when in a custom Rails environment' do
+      let(:rails_env) { "custom" }
+
+      it 'returns :production' do
+        expect(subject.environment).to eq(:production)
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Avatax client requires an environment to be set when initializing.

This sets it to `:sandbox` when in a test Rails environment, otherwise falls back to the previous implementation (`null` avatax env for `test` Rails env, `production` for all others).